### PR TITLE
Update batch dcm2nifti script

### DIFF
--- a/batch_dicom_to_nifti.sh
+++ b/batch_dicom_to_nifti.sh
@@ -27,10 +27,10 @@
 # correctly parse your data. More information can be found here: https://unfmontreal.github.io/Dcm2Bids/docs/how-to/create-config-file/
 
 # Create the absolute path out of the input provided to the script
-INPUT_PATH="$(cd "$(dirname "${1}")" || exit; pwd)/$(basename "${1}")"
+INPUT_PATH="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 
 # Create the absolute path out of the input provided to the script
-OUTPUT_PATH="$(cd "$(dirname "${2}")" || exit; pwd)/$(basename "${2}")"
+OUTPUT_PATH="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 
 # Run st_dicom_to_nifti on each folder
 for FNAME in "${INPUT_PATH}/"*; do

--- a/batch_dicom_to_nifti.sh
+++ b/batch_dicom_to_nifti.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Perform st_dicom_to_nifti on multiple folders and store the NIfTI files in BIDS format.
+#
+# The script takes in an argument on the command line to where a folder of folders of DICOMs is located. The script
+# will run st_dicom_to_nifti on each folder inside the folder of the first argument and use their name to differentiate
+# them in the output. It will output in the output folder (2nd argument) in BIDS format.
+#
+# Example:
+# sh batch_dicom_to_nifti.sh input_folder output_folder
+#
+#
+# Input folder structure:
+# input_folder/
+# input_folder/subject1/
+# input_folder/subject2/
+#
+# Output folder structure
+# output_folder/bids_folder/sub-subject1/...
+# output_folder/bids_folder/sub-subject2/...
+#
+# Note:
+# If you do not see your data in the above mentioned folders, they should be located in
+# output_folder/bids_folder/tmp_dcm2bids/sub-... If that is the case, the issue is that st_dicom_to_nifti requires a BIDS
+# config file to correctly output the NIfTI files in the appropriate folders. To fix the problem, you can modify the
+# config file by first locating it ("st_dicom_to_nifti -h" and looking for the option --config) and changing it to
+# correctly parse your data. More information can be found here: https://unfmontreal.github.io/Dcm2Bids/docs/how-to/create-config-file/
+
+# Create the absolute path out of the input provided to the script
+INPUT_PATH="$(cd "$(dirname "${1}")" || exit; pwd)/$(basename "${1}")"
+
+# Create the absolute path out of the input provided to the script
+OUTPUT_PATH="$(cd "$(dirname "${2}")" || exit; pwd)/$(basename "${2}")"
+
+# Run st_dicom_to_nifti on each folder
+for FNAME in "${INPUT_PATH}/"*; do
+  if [[ -d "${FNAME}" && ! -L "${FNAME}" ]]; then
+
+    echo "Processing: ${FNAME}"
+    BASENAME="$(basename "${FNAME}")"
+    st_dicom_to_nifti -i "${FNAME}" -o "${OUTPUT_PATH}/bids_folder" --subject "${BASENAME}" || exit
+
+  fi
+done
+
+echo -e "\n\033[0;32mOutput is located here: ${OUTPUT_PATH}/bids_folder"

--- a/batch_dicom_to_nifti.sh
+++ b/batch_dicom_to_nifti.sh
@@ -30,7 +30,7 @@
 INPUT_PATH="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 
 # Create the absolute path out of the input provided to the script
-OUTPUT_PATH="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+OUTPUT_PATH="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
 
 # Run st_dicom_to_nifti on each folder
 for FNAME in "${INPUT_PATH}/"*; do

--- a/demo_config_coil_profile.json
+++ b/demo_config_coil_profile.json
@@ -1,0 +1,316 @@
+{
+  "phase": [
+    [
+      [
+        "bids_folder/sub-36-fm2d_CH1_-0.5A/fmap/sub-36-fm2d_CH1_-0.5A_phase1.nii.gz",
+        "bids_folder/sub-36-fm2d_CH1_-0.5A/fmap/sub-36-fm2d_CH1_-0.5A_phase2.nii.gz",
+        "bids_folder/sub-36-fm2d_CH1_-0.5A/fmap/sub-36-fm2d_CH1_-0.5A_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-34-fm2d_CH1_+0.5A/fmap/sub-34-fm2d_CH1_+0.5A_phase1.nii.gz",
+        "bids_folder/sub-34-fm2d_CH1_+0.5A/fmap/sub-34-fm2d_CH1_+0.5A_phase2.nii.gz",
+        "bids_folder/sub-34-fm2d_CH1_+0.5A/fmap/sub-34-fm2d_CH1_+0.5A_phase3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-40-fm2d_CH2_-0.5A/fmap/sub-40-fm2d_CH2_-0.5A_phase1.nii.gz",
+        "bids_folder/sub-40-fm2d_CH2_-0.5A/fmap/sub-40-fm2d_CH2_-0.5A_phase2.nii.gz",
+        "bids_folder/sub-40-fm2d_CH2_-0.5A/fmap/sub-40-fm2d_CH2_-0.5A_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-38-fm2d_CH2_+0.5A/fmap/sub-38-fm2d_CH2_+0.5A_phase1.nii.gz",
+        "bids_folder/sub-38-fm2d_CH2_+0.5A/fmap/sub-38-fm2d_CH2_+0.5A_phase2.nii.gz",
+        "bids_folder/sub-38-fm2d_CH2_+0.5A/fmap/sub-38-fm2d_CH2_+0.5A_phase3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-44-fm2d_CH3_-0.5A/fmap/sub-44-fm2d_CH3_-0.5A_phase1.nii.gz",
+        "bids_folder/sub-44-fm2d_CH3_-0.5A/fmap/sub-44-fm2d_CH3_-0.5A_phase2.nii.gz",
+        "bids_folder/sub-44-fm2d_CH3_-0.5A/fmap/sub-44-fm2d_CH3_-0.5A_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-42-fm2d_CH3_+0.5A/fmap/sub-42-fm2d_CH3_+0.5A_phase1.nii.gz",
+        "bids_folder/sub-42-fm2d_CH3_+0.5A/fmap/sub-42-fm2d_CH3_+0.5A_phase2.nii.gz",
+        "bids_folder/sub-42-fm2d_CH3_+0.5A/fmap/sub-42-fm2d_CH3_+0.5A_phase3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-48-fm2d_CH4_-0.5A/fmap/sub-48-fm2d_CH4_-0.5A_phase1.nii.gz",
+        "bids_folder/sub-48-fm2d_CH4_-0.5A/fmap/sub-48-fm2d_CH4_-0.5A_phase2.nii.gz",
+        "bids_folder/sub-48-fm2d_CH4_-0.5A/fmap/sub-48-fm2d_CH4_-0.5A_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-46-fm2d_CH4_+0.5A/fmap/sub-46-fm2d_CH4_+0.5A_phase1.nii.gz",
+        "bids_folder/sub-46-fm2d_CH4_+0.5A/fmap/sub-46-fm2d_CH4_+0.5A_phase2.nii.gz",
+        "bids_folder/sub-46-fm2d_CH4_+0.5A/fmap/sub-46-fm2d_CH4_+0.5A_phase3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-52-fm2d_CH5_-0.5A/fmap/sub-52-fm2d_CH5_-0.5A_phase1.nii.gz",
+        "bids_folder/sub-52-fm2d_CH5_-0.5A/fmap/sub-52-fm2d_CH5_-0.5A_phase2.nii.gz",
+        "bids_folder/sub-52-fm2d_CH5_-0.5A/fmap/sub-52-fm2d_CH5_-0.5A_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-50-fm2d_CH5_+0.5A/fmap/sub-50-fm2d_CH5_+0.5A_phase1.nii.gz",
+        "bids_folder/sub-50-fm2d_CH5_+0.5A/fmap/sub-50-fm2d_CH5_+0.5A_phase2.nii.gz",
+        "bids_folder/sub-50-fm2d_CH5_+0.5A/fmap/sub-50-fm2d_CH5_+0.5A_phase3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-58-fm2d_CH6_-0.5A/fmap/sub-58-fm2d_CH6_-0.5A_phase1.nii.gz",
+        "bids_folder/sub-58-fm2d_CH6_-0.5A/fmap/sub-58-fm2d_CH6_-0.5A_phase2.nii.gz",
+        "bids_folder/sub-58-fm2d_CH6_-0.5A/fmap/sub-58-fm2d_CH6_-0.5A_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-54-fm2d_CH6_+0.5A/fmap/sub-54-fm2d_CH6_+0.5A_phase1.nii.gz",
+        "bids_folder/sub-54-fm2d_CH6_+0.5A/fmap/sub-54-fm2d_CH6_+0.5A_phase2.nii.gz",
+        "bids_folder/sub-54-fm2d_CH6_+0.5A/fmap/sub-54-fm2d_CH6_+0.5A_phase3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-62-fm2d_CH7_-0.5A/fmap/sub-62-fm2d_CH7_-0.5A_phase1.nii.gz",
+        "bids_folder/sub-62-fm2d_CH7_-0.5A/fmap/sub-62-fm2d_CH7_-0.5A_phase2.nii.gz",
+        "bids_folder/sub-62-fm2d_CH7_-0.5A/fmap/sub-62-fm2d_CH7_-0.5A_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-60-fm2d_CH7_+0.5A/fmap/sub-60-fm2d_CH7_+0.5A_phase1.nii.gz",
+        "bids_folder/sub-60-fm2d_CH7_+0.5A/fmap/sub-60-fm2d_CH7_+0.5A_phase2.nii.gz",
+        "bids_folder/sub-60-fm2d_CH7_+0.5A/fmap/sub-60-fm2d_CH7_+0.5A_phase3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-66-fm2d_CH8_-0.5A/fmap/sub-66-fm2d_CH8_-0.5A_phase1.nii.gz",
+        "bids_folder/sub-66-fm2d_CH8_-0.5A/fmap/sub-66-fm2d_CH8_-0.5A_phase2.nii.gz",
+        "bids_folder/sub-66-fm2d_CH8_-0.5A/fmap/sub-66-fm2d_CH8_-0.5A_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
+        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-64-fm2d_CH8_+0.5A/fmap/sub-64-fm2d_CH8_+0.5A_phase1.nii.gz",
+        "bids_folder/sub-64-fm2d_CH8_+0.5A/fmap/sub-64-fm2d_CH8_+0.5A_phase2.nii.gz",
+        "bids_folder/sub-64-fm2d_CH8_+0.5A/fmap/sub-64-fm2d_CH8_+0.5A_phase3.nii.gz"
+      ]
+    ]
+  ],
+  "mag":[
+    [
+      [
+        "bids_folder/sub-35-fm2d_CH1_-0.5A/fmap/sub-35-fm2d_CH1_-0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-35-fm2d_CH1_-0.5A/fmap/sub-35-fm2d_CH1_-0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-35-fm2d_CH1_-0.5A/fmap/sub-35-fm2d_CH1_-0.5A_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-33-fm2d_CH1_+0.5A/fmap/sub-33-fm2d_CH1_+0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-33-fm2d_CH1_+0.5A/fmap/sub-33-fm2d_CH1_+0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-33-fm2d_CH1_+0.5A/fmap/sub-33-fm2d_CH1_+0.5A_magnitude3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-39-fm2d_CH2_-0.5A/fmap/sub-39-fm2d_CH2_-0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-39-fm2d_CH2_-0.5A/fmap/sub-39-fm2d_CH2_-0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-39-fm2d_CH2_-0.5A/fmap/sub-39-fm2d_CH2_-0.5A_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-37-fm2d_CH2_+0.5A/fmap/sub-37-fm2d_CH2_+0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-37-fm2d_CH2_+0.5A/fmap/sub-37-fm2d_CH2_+0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-37-fm2d_CH2_+0.5A/fmap/sub-37-fm2d_CH2_+0.5A_magnitude3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-43-fm2d_CH3_-0.5A/fmap/sub-43-fm2d_CH3_-0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-43-fm2d_CH3_-0.5A/fmap/sub-43-fm2d_CH3_-0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-43-fm2d_CH3_-0.5A/fmap/sub-43-fm2d_CH3_-0.5A_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-41-fm2d_CH3_+0.5A/fmap/sub-41-fm2d_CH3_+0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-41-fm2d_CH3_+0.5A/fmap/sub-41-fm2d_CH3_+0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-41-fm2d_CH3_+0.5A/fmap/sub-41-fm2d_CH3_+0.5A_magnitude3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-47-fm2d_CH4_-0.5A/fmap/sub-47-fm2d_CH4_-0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-47-fm2d_CH4_-0.5A/fmap/sub-47-fm2d_CH4_-0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-47-fm2d_CH4_-0.5A/fmap/sub-47-fm2d_CH4_-0.5A_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-45-fm2d_CH4_+0.5A/fmap/sub-45-fm2d_CH4_+0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-45-fm2d_CH4_+0.5A/fmap/sub-45-fm2d_CH4_+0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-45-fm2d_CH4_+0.5A/fmap/sub-45-fm2d_CH4_+0.5A_magnitude3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-51-fm2d_CH5_-0.5A/fmap/sub-51-fm2d_CH5_-0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-51-fm2d_CH5_-0.5A/fmap/sub-51-fm2d_CH5_-0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-51-fm2d_CH5_-0.5A/fmap/sub-51-fm2d_CH5_-0.5A_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-49-fm2d_CH5_+0.5A/fmap/sub-49-fm2d_CH5_+0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-49-fm2d_CH5_+0.5A/fmap/sub-49-fm2d_CH5_+0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-49-fm2d_CH5_+0.5A/fmap/sub-49-fm2d_CH5_+0.5A_magnitude3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-57-fm2d_CH6_-0.5A/fmap/sub-57-fm2d_CH6_-0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-57-fm2d_CH6_-0.5A/fmap/sub-57-fm2d_CH6_-0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-57-fm2d_CH6_-0.5A/fmap/sub-57-fm2d_CH6_-0.5A_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-53-fm2d_CH6_+0.5A/fmap/sub-53-fm2d_CH6_+0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-53-fm2d_CH6_+0.5A/fmap/sub-53-fm2d_CH6_+0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-53-fm2d_CH6_+0.5A/fmap/sub-53-fm2d_CH6_+0.5A_magnitude3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-61-fm2d_CH7_-0.5A/fmap/sub-61-fm2d_CH7_-0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-61-fm2d_CH7_-0.5A/fmap/sub-61-fm2d_CH7_-0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-61-fm2d_CH7_-0.5A/fmap/sub-61-fm2d_CH7_-0.5A_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-59-fm2d_CH7_+0.5A/fmap/sub-59-fm2d_CH7_+0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-59-fm2d_CH7_+0.5A/fmap/sub-59-fm2d_CH7_+0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-59-fm2d_CH7_+0.5A/fmap/sub-59-fm2d_CH7_+0.5A_magnitude3.nii.gz"
+      ]
+    ],
+
+    [
+      [
+        "bids_folder/sub-65-fm2d_CH8_-0.5A/fmap/sub-65-fm2d_CH8_-0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-65-fm2d_CH8_-0.5A/fmap/sub-65-fm2d_CH8_-0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-65-fm2d_CH8_-0.5A/fmap/sub-65-fm2d_CH8_-0.5A_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+      ],
+      [
+        "bids_folder/sub-63-fm2d_CH8_+0.5A/fmap/sub-63-fm2d_CH8_+0.5A_magnitude1.nii.gz",
+        "bids_folder/sub-63-fm2d_CH8_+0.5A/fmap/sub-63-fm2d_CH8_+0.5A_magnitude2.nii.gz",
+        "bids_folder/sub-63-fm2d_CH8_+0.5A/fmap/sub-63-fm2d_CH8_+0.5A_magnitude3.nii.gz"
+      ]
+    ]
+  ],
+  "setup_currents": [
+    [-0.5, 0, 0.5],
+    [-0.5, 0, 0.5],
+    [-0.5, 0, 0.5],
+    [-0.5, 0, 0.5],
+    [-0.5, 0, 0.5],
+    [-0.5, 0, 0.5],
+    [-0.5, 0, 0.5],
+    [-0.5, 0, 0.5]
+  ],
+  "name": "greg_coil",
+  "n_channels": 8,
+  "units": "A",
+  "coef_channel_minmax": [
+    [-2.5, 2.5],
+    [-2.5, 2.5],
+    [-2.5, 2.5],
+    [-2.5, 2.5],
+    [-2.5, 2.5],
+    [-2.5, 2.5],
+    [-2.5, 2.5],
+    [-2.5, 2.5]
+  ],
+  "coef_sum_max": null
+}


### PR DESCRIPTION
The output path of the previous version was working but the output name could have "." in the name. This PR addresses this problem and expands the "." into the full path correctly.