### PR TITLE
Update batch dcm2nifti script paths

### DIFF
--- a/batch_dicom_to_nifti.sh
+++ b/batch_dicom_to_nifti.sh
@@ -27,10 +27,10 @@
 # correctly parse your data. More information can be found here: https://unfmontreal.github.io/Dcm2Bids/docs/how-to/create-config-file/
 
 # Create the absolute path out of the input provided to the script
-INPUT_PATH="$(cd "$(dirname "${1}")" || exit; pwd)/$(basename "${1}")"
+INPUT_PATH="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 
 # Create the absolute path out of the input provided to the script
-OUTPUT_PATH="$(cd "$(dirname "${2}")" || exit; pwd)/$(basename "${2}")"
+OUTPUT_PATH="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
 
 # Run st_dicom_to_nifti on each folder
 for FNAME in "${INPUT_PATH}/"*; do


### PR DESCRIPTION
The output path of the previous version was working but the output name could have "." in the name. This PR addresses this problem and expands the "." into the full path correctly.