### PR TITLE
Update to follow dcm2bids 3.0

### DIFF
--- a/batch_dicom_to_nifti.sh
+++ b/batch_dicom_to_nifti.sh
@@ -4,7 +4,9 @@
 #
 # The script takes in an argument on the command line to where a folder of folders of DICOMs is located. The script
 # will run st_dicom_to_nifti on each folder inside the folder of the first argument and use their name to differentiate
-# them in the output. It will output in the output folder (2nd argument) in BIDS format.
+# them in the output. Since the BIDS specification requires alphanumerical labels, non alphanumerical characters
+# will be stripped from the folder names when converting to participant labels. It will output in the output folder
+# (2nd argument) in BIDS format.
 #
 # Example:
 # sh batch_dicom_to_nifti.sh input_folder output_folder
@@ -12,8 +14,8 @@
 #
 # Input folder structure:
 # input_folder/
-# input_folder/subject1/
-# input_folder/subject2/
+# input_folder/subject_1/
+# input_folder/subject_2/
 #
 # Output folder structure
 # output_folder/bids_folder/sub-subject1/...
@@ -27,20 +29,24 @@
 # correctly parse your data. More information can be found here: https://unfmontreal.github.io/Dcm2Bids/docs/how-to/create-config-file/
 
 # Create the absolute path out of the input provided to the script
-INPUT_PATH="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+INPUT_PATH="$( cd -- "${1}" >/dev/null 2>&1 ; pwd -P )"
+echo "Input path: ${INPUT_PATH}"
 
 # Create the absolute path out of the input provided to the script
-OUTPUT_PATH="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
+OUTPUT_PATH="$( cd -- "${2}" >/dev/null 2>&1 ; pwd -P )"
+echo "Output path: ${OUTPUT_PATH}"
+echo
 
 # Run st_dicom_to_nifti on each folder
 for FNAME in "${INPUT_PATH}/"*; do
   if [[ -d "${FNAME}" && ! -L "${FNAME}" ]]; then
 
     echo "Processing: ${FNAME}"
-    BASENAME="$(basename "${FNAME}")"
+
+    BASENAME="$(echo "$(basename "${FNAME}")" | tr -cd '[a-zA-Z0-9]')"
     st_dicom_to_nifti -i "${FNAME}" -o "${OUTPUT_PATH}/bids_folder" --subject "${BASENAME}" || exit
 
   fi
 done
 
-echo -e "\n\033[0;32mOutput is located here: ${OUTPUT_PATH}/bids_folder"
+echo -e "\n\033[0;32mOutput is located in: ${OUTPUT_PATH}/bids_folder"

--- a/demo_config_coil_profile.json
+++ b/demo_config_coil_profile.json
@@ -1,291 +1,294 @@
 {
+  "comments": ["Since JSON files do not allow comments, this variable can be omitted and only serves as a way to provide comments",
+  "The BIDS specification requires alphanumerical labels which is why the acquisition names differ from the DICOMs.",
+  "Use the acquisition number to differentiate similar ones (i.e. bids_folder/sub-36fm2dCH105A refers to dicoms_sorted/36-fm2d_CH1_-0.5A)"],
   "phase": [
     [
       [
-        "bids_folder/sub-36-fm2d_CH1_-0.5A/fmap/sub-36-fm2d_CH1_-0.5A_phase1.nii.gz",
-        "bids_folder/sub-36-fm2d_CH1_-0.5A/fmap/sub-36-fm2d_CH1_-0.5A_phase2.nii.gz",
-        "bids_folder/sub-36-fm2d_CH1_-0.5A/fmap/sub-36-fm2d_CH1_-0.5A_phase3.nii.gz"
+        "bids_folder/sub-36fm2dCH105A/fmap/sub-36fm2dCH105A_phase1.nii.gz",
+        "bids_folder/sub-36fm2dCH105A/fmap/sub-36fm2dCH105A_phase2.nii.gz",
+        "bids_folder/sub-36fm2dCH105A/fmap/sub-36fm2dCH105A_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase1.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase2.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-34-fm2d_CH1_+0.5A/fmap/sub-34-fm2d_CH1_+0.5A_phase1.nii.gz",
-        "bids_folder/sub-34-fm2d_CH1_+0.5A/fmap/sub-34-fm2d_CH1_+0.5A_phase2.nii.gz",
-        "bids_folder/sub-34-fm2d_CH1_+0.5A/fmap/sub-34-fm2d_CH1_+0.5A_phase3.nii.gz"
+        "bids_folder/sub-34fm2dCH105A/fmap/sub-34fm2dCH105A_phase1.nii.gz",
+        "bids_folder/sub-34fm2dCH105A/fmap/sub-34fm2dCH105A_phase2.nii.gz",
+        "bids_folder/sub-34fm2dCH105A/fmap/sub-34fm2dCH105A_phase3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-40-fm2d_CH2_-0.5A/fmap/sub-40-fm2d_CH2_-0.5A_phase1.nii.gz",
-        "bids_folder/sub-40-fm2d_CH2_-0.5A/fmap/sub-40-fm2d_CH2_-0.5A_phase2.nii.gz",
-        "bids_folder/sub-40-fm2d_CH2_-0.5A/fmap/sub-40-fm2d_CH2_-0.5A_phase3.nii.gz"
+        "bids_folder/sub-40fm2dCH205A/fmap/sub-40fm2dCH205A_phase1.nii.gz",
+        "bids_folder/sub-40fm2dCH205A/fmap/sub-40fm2dCH205A_phase2.nii.gz",
+        "bids_folder/sub-40fm2dCH205A/fmap/sub-40fm2dCH205A_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase1.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase2.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-38-fm2d_CH2_+0.5A/fmap/sub-38-fm2d_CH2_+0.5A_phase1.nii.gz",
-        "bids_folder/sub-38-fm2d_CH2_+0.5A/fmap/sub-38-fm2d_CH2_+0.5A_phase2.nii.gz",
-        "bids_folder/sub-38-fm2d_CH2_+0.5A/fmap/sub-38-fm2d_CH2_+0.5A_phase3.nii.gz"
+        "bids_folder/sub-38fm2dCH205A/fmap/sub-38fm2dCH205A_phase1.nii.gz",
+        "bids_folder/sub-38fm2dCH205A/fmap/sub-38fm2dCH205A_phase2.nii.gz",
+        "bids_folder/sub-38fm2dCH205A/fmap/sub-38fm2dCH205A_phase3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-44-fm2d_CH3_-0.5A/fmap/sub-44-fm2d_CH3_-0.5A_phase1.nii.gz",
-        "bids_folder/sub-44-fm2d_CH3_-0.5A/fmap/sub-44-fm2d_CH3_-0.5A_phase2.nii.gz",
-        "bids_folder/sub-44-fm2d_CH3_-0.5A/fmap/sub-44-fm2d_CH3_-0.5A_phase3.nii.gz"
+        "bids_folder/sub-44fm2dCH305A/fmap/sub-44fm2dCH305A_phase1.nii.gz",
+        "bids_folder/sub-44fm2dCH305A/fmap/sub-44fm2dCH305A_phase2.nii.gz",
+        "bids_folder/sub-44fm2dCH305A/fmap/sub-44fm2dCH305A_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase1.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase2.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-42-fm2d_CH3_+0.5A/fmap/sub-42-fm2d_CH3_+0.5A_phase1.nii.gz",
-        "bids_folder/sub-42-fm2d_CH3_+0.5A/fmap/sub-42-fm2d_CH3_+0.5A_phase2.nii.gz",
-        "bids_folder/sub-42-fm2d_CH3_+0.5A/fmap/sub-42-fm2d_CH3_+0.5A_phase3.nii.gz"
+        "bids_folder/sub-42fm2dCH305A/fmap/sub-42fm2dCH305A_phase1.nii.gz",
+        "bids_folder/sub-42fm2dCH305A/fmap/sub-42fm2dCH305A_phase2.nii.gz",
+        "bids_folder/sub-42fm2dCH305A/fmap/sub-42fm2dCH305A_phase3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-48-fm2d_CH4_-0.5A/fmap/sub-48-fm2d_CH4_-0.5A_phase1.nii.gz",
-        "bids_folder/sub-48-fm2d_CH4_-0.5A/fmap/sub-48-fm2d_CH4_-0.5A_phase2.nii.gz",
-        "bids_folder/sub-48-fm2d_CH4_-0.5A/fmap/sub-48-fm2d_CH4_-0.5A_phase3.nii.gz"
+        "bids_folder/sub-48fm2dCH405A/fmap/sub-48fm2dCH405A_phase1.nii.gz",
+        "bids_folder/sub-48fm2dCH405A/fmap/sub-48fm2dCH405A_phase2.nii.gz",
+        "bids_folder/sub-48fm2dCH405A/fmap/sub-48fm2dCH405A_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase1.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase2.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-46-fm2d_CH4_+0.5A/fmap/sub-46-fm2d_CH4_+0.5A_phase1.nii.gz",
-        "bids_folder/sub-46-fm2d_CH4_+0.5A/fmap/sub-46-fm2d_CH4_+0.5A_phase2.nii.gz",
-        "bids_folder/sub-46-fm2d_CH4_+0.5A/fmap/sub-46-fm2d_CH4_+0.5A_phase3.nii.gz"
+        "bids_folder/sub-46fm2dCH405A/fmap/sub-46fm2dCH405A_phase1.nii.gz",
+        "bids_folder/sub-46fm2dCH405A/fmap/sub-46fm2dCH405A_phase2.nii.gz",
+        "bids_folder/sub-46fm2dCH405A/fmap/sub-46fm2dCH405A_phase3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-52-fm2d_CH5_-0.5A/fmap/sub-52-fm2d_CH5_-0.5A_phase1.nii.gz",
-        "bids_folder/sub-52-fm2d_CH5_-0.5A/fmap/sub-52-fm2d_CH5_-0.5A_phase2.nii.gz",
-        "bids_folder/sub-52-fm2d_CH5_-0.5A/fmap/sub-52-fm2d_CH5_-0.5A_phase3.nii.gz"
+        "bids_folder/sub-52fm2dCH505A/fmap/sub-52fm2dCH505A_phase1.nii.gz",
+        "bids_folder/sub-52fm2dCH505A/fmap/sub-52fm2dCH505A_phase2.nii.gz",
+        "bids_folder/sub-52fm2dCH505A/fmap/sub-52fm2dCH505A_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase1.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase2.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-50-fm2d_CH5_+0.5A/fmap/sub-50-fm2d_CH5_+0.5A_phase1.nii.gz",
-        "bids_folder/sub-50-fm2d_CH5_+0.5A/fmap/sub-50-fm2d_CH5_+0.5A_phase2.nii.gz",
-        "bids_folder/sub-50-fm2d_CH5_+0.5A/fmap/sub-50-fm2d_CH5_+0.5A_phase3.nii.gz"
+        "bids_folder/sub-50fm2dCH505A/fmap/sub-50fm2dCH505A_phase1.nii.gz",
+        "bids_folder/sub-50fm2dCH505A/fmap/sub-50fm2dCH505A_phase2.nii.gz",
+        "bids_folder/sub-50fm2dCH505A/fmap/sub-50fm2dCH505A_phase3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-58-fm2d_CH6_-0.5A/fmap/sub-58-fm2d_CH6_-0.5A_phase1.nii.gz",
-        "bids_folder/sub-58-fm2d_CH6_-0.5A/fmap/sub-58-fm2d_CH6_-0.5A_phase2.nii.gz",
-        "bids_folder/sub-58-fm2d_CH6_-0.5A/fmap/sub-58-fm2d_CH6_-0.5A_phase3.nii.gz"
+        "bids_folder/sub-58fm2dCH605A/fmap/sub-58fm2dCH605A_phase1.nii.gz",
+        "bids_folder/sub-58fm2dCH605A/fmap/sub-58fm2dCH605A_phase2.nii.gz",
+        "bids_folder/sub-58fm2dCH605A/fmap/sub-58fm2dCH605A_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase1.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase2.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-54-fm2d_CH6_+0.5A/fmap/sub-54-fm2d_CH6_+0.5A_phase1.nii.gz",
-        "bids_folder/sub-54-fm2d_CH6_+0.5A/fmap/sub-54-fm2d_CH6_+0.5A_phase2.nii.gz",
-        "bids_folder/sub-54-fm2d_CH6_+0.5A/fmap/sub-54-fm2d_CH6_+0.5A_phase3.nii.gz"
+        "bids_folder/sub-54fm2dCH605A/fmap/sub-54fm2dCH605A_phase1.nii.gz",
+        "bids_folder/sub-54fm2dCH605A/fmap/sub-54fm2dCH605A_phase2.nii.gz",
+        "bids_folder/sub-54fm2dCH605A/fmap/sub-54fm2dCH605A_phase3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-62-fm2d_CH7_-0.5A/fmap/sub-62-fm2d_CH7_-0.5A_phase1.nii.gz",
-        "bids_folder/sub-62-fm2d_CH7_-0.5A/fmap/sub-62-fm2d_CH7_-0.5A_phase2.nii.gz",
-        "bids_folder/sub-62-fm2d_CH7_-0.5A/fmap/sub-62-fm2d_CH7_-0.5A_phase3.nii.gz"
+        "bids_folder/sub-62fm2dCH705A/fmap/sub-62fm2dCH705A_phase1.nii.gz",
+        "bids_folder/sub-62fm2dCH705A/fmap/sub-62fm2dCH705A_phase2.nii.gz",
+        "bids_folder/sub-62fm2dCH705A/fmap/sub-62fm2dCH705A_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase1.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase2.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-60-fm2d_CH7_+0.5A/fmap/sub-60-fm2d_CH7_+0.5A_phase1.nii.gz",
-        "bids_folder/sub-60-fm2d_CH7_+0.5A/fmap/sub-60-fm2d_CH7_+0.5A_phase2.nii.gz",
-        "bids_folder/sub-60-fm2d_CH7_+0.5A/fmap/sub-60-fm2d_CH7_+0.5A_phase3.nii.gz"
+        "bids_folder/sub-60fm2dCH705A/fmap/sub-60fm2dCH705A_phase1.nii.gz",
+        "bids_folder/sub-60fm2dCH705A/fmap/sub-60fm2dCH705A_phase2.nii.gz",
+        "bids_folder/sub-60fm2dCH705A/fmap/sub-60fm2dCH705A_phase3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-66-fm2d_CH8_-0.5A/fmap/sub-66-fm2d_CH8_-0.5A_phase1.nii.gz",
-        "bids_folder/sub-66-fm2d_CH8_-0.5A/fmap/sub-66-fm2d_CH8_-0.5A_phase2.nii.gz",
-        "bids_folder/sub-66-fm2d_CH8_-0.5A/fmap/sub-66-fm2d_CH8_-0.5A_phase3.nii.gz"
+        "bids_folder/sub-66fm2dCH805A/fmap/sub-66fm2dCH805A_phase1.nii.gz",
+        "bids_folder/sub-66fm2dCH805A/fmap/sub-66fm2dCH805A_phase2.nii.gz",
+        "bids_folder/sub-66fm2dCH805A/fmap/sub-66fm2dCH805A_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase1.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase2.nii.gz",
-        "bids_folder/sub-28-fm2d_CH0_baseline/fmap/sub-28-fm2d_CH0_baseline_phase3.nii.gz"
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase1.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase2.nii.gz",
+        "bids_folder/sub-28fm2dCH0baseline/fmap/sub-28fm2dCH0baseline_phase3.nii.gz"
       ],
       [
-        "bids_folder/sub-64-fm2d_CH8_+0.5A/fmap/sub-64-fm2d_CH8_+0.5A_phase1.nii.gz",
-        "bids_folder/sub-64-fm2d_CH8_+0.5A/fmap/sub-64-fm2d_CH8_+0.5A_phase2.nii.gz",
-        "bids_folder/sub-64-fm2d_CH8_+0.5A/fmap/sub-64-fm2d_CH8_+0.5A_phase3.nii.gz"
+        "bids_folder/sub-64fm2dCH805A/fmap/sub-64fm2dCH805A_phase1.nii.gz",
+        "bids_folder/sub-64fm2dCH805A/fmap/sub-64fm2dCH805A_phase2.nii.gz",
+        "bids_folder/sub-64fm2dCH805A/fmap/sub-64fm2dCH805A_phase3.nii.gz"
       ]
     ]
   ],
   "mag":[
     [
       [
-        "bids_folder/sub-35-fm2d_CH1_-0.5A/fmap/sub-35-fm2d_CH1_-0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-35-fm2d_CH1_-0.5A/fmap/sub-35-fm2d_CH1_-0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-35-fm2d_CH1_-0.5A/fmap/sub-35-fm2d_CH1_-0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-35fm2dCH105A/fmap/sub-35fm2dCH105A_magnitude1.nii.gz",
+        "bids_folder/sub-35fm2dCH105A/fmap/sub-35fm2dCH105A_magnitude2.nii.gz",
+        "bids_folder/sub-35fm2dCH105A/fmap/sub-35fm2dCH105A_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-33-fm2d_CH1_+0.5A/fmap/sub-33-fm2d_CH1_+0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-33-fm2d_CH1_+0.5A/fmap/sub-33-fm2d_CH1_+0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-33-fm2d_CH1_+0.5A/fmap/sub-33-fm2d_CH1_+0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-33fm2dCH105A/fmap/sub-33fm2dCH105A_magnitude1.nii.gz",
+        "bids_folder/sub-33fm2dCH105A/fmap/sub-33fm2dCH105A_magnitude2.nii.gz",
+        "bids_folder/sub-33fm2dCH105A/fmap/sub-33fm2dCH105A_magnitude3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-39-fm2d_CH2_-0.5A/fmap/sub-39-fm2d_CH2_-0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-39-fm2d_CH2_-0.5A/fmap/sub-39-fm2d_CH2_-0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-39-fm2d_CH2_-0.5A/fmap/sub-39-fm2d_CH2_-0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-39fm2dCH205A/fmap/sub-39fm2dCH205A_magnitude1.nii.gz",
+        "bids_folder/sub-39fm2dCH205A/fmap/sub-39fm2dCH205A_magnitude2.nii.gz",
+        "bids_folder/sub-39fm2dCH205A/fmap/sub-39fm2dCH205A_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-37-fm2d_CH2_+0.5A/fmap/sub-37-fm2d_CH2_+0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-37-fm2d_CH2_+0.5A/fmap/sub-37-fm2d_CH2_+0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-37-fm2d_CH2_+0.5A/fmap/sub-37-fm2d_CH2_+0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-37fm2dCH205A/fmap/sub-37fm2dCH205A_magnitude1.nii.gz",
+        "bids_folder/sub-37fm2dCH205A/fmap/sub-37fm2dCH205A_magnitude2.nii.gz",
+        "bids_folder/sub-37fm2dCH205A/fmap/sub-37fm2dCH205A_magnitude3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-43-fm2d_CH3_-0.5A/fmap/sub-43-fm2d_CH3_-0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-43-fm2d_CH3_-0.5A/fmap/sub-43-fm2d_CH3_-0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-43-fm2d_CH3_-0.5A/fmap/sub-43-fm2d_CH3_-0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-43fm2dCH305A/fmap/sub-43fm2dCH305A_magnitude1.nii.gz",
+        "bids_folder/sub-43fm2dCH305A/fmap/sub-43fm2dCH305A_magnitude2.nii.gz",
+        "bids_folder/sub-43fm2dCH305A/fmap/sub-43fm2dCH305A_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-41-fm2d_CH3_+0.5A/fmap/sub-41-fm2d_CH3_+0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-41-fm2d_CH3_+0.5A/fmap/sub-41-fm2d_CH3_+0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-41-fm2d_CH3_+0.5A/fmap/sub-41-fm2d_CH3_+0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-41fm2dCH305A/fmap/sub-41fm2dCH305A_magnitude1.nii.gz",
+        "bids_folder/sub-41fm2dCH305A/fmap/sub-41fm2dCH305A_magnitude2.nii.gz",
+        "bids_folder/sub-41fm2dCH305A/fmap/sub-41fm2dCH305A_magnitude3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-47-fm2d_CH4_-0.5A/fmap/sub-47-fm2d_CH4_-0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-47-fm2d_CH4_-0.5A/fmap/sub-47-fm2d_CH4_-0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-47-fm2d_CH4_-0.5A/fmap/sub-47-fm2d_CH4_-0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-47fm2dCH405A/fmap/sub-47fm2dCH405A_magnitude1.nii.gz",
+        "bids_folder/sub-47fm2dCH405A/fmap/sub-47fm2dCH405A_magnitude2.nii.gz",
+        "bids_folder/sub-47fm2dCH405A/fmap/sub-47fm2dCH405A_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-45-fm2d_CH4_+0.5A/fmap/sub-45-fm2d_CH4_+0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-45-fm2d_CH4_+0.5A/fmap/sub-45-fm2d_CH4_+0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-45-fm2d_CH4_+0.5A/fmap/sub-45-fm2d_CH4_+0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-45fm2dCH405A/fmap/sub-45fm2dCH405A_magnitude1.nii.gz",
+        "bids_folder/sub-45fm2dCH405A/fmap/sub-45fm2dCH405A_magnitude2.nii.gz",
+        "bids_folder/sub-45fm2dCH405A/fmap/sub-45fm2dCH405A_magnitude3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-51-fm2d_CH5_-0.5A/fmap/sub-51-fm2d_CH5_-0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-51-fm2d_CH5_-0.5A/fmap/sub-51-fm2d_CH5_-0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-51-fm2d_CH5_-0.5A/fmap/sub-51-fm2d_CH5_-0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-51fm2dCH505A/fmap/sub-51fm2dCH505A_magnitude1.nii.gz",
+        "bids_folder/sub-51fm2dCH505A/fmap/sub-51fm2dCH505A_magnitude2.nii.gz",
+        "bids_folder/sub-51fm2dCH505A/fmap/sub-51fm2dCH505A_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-49-fm2d_CH5_+0.5A/fmap/sub-49-fm2d_CH5_+0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-49-fm2d_CH5_+0.5A/fmap/sub-49-fm2d_CH5_+0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-49-fm2d_CH5_+0.5A/fmap/sub-49-fm2d_CH5_+0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-49fm2dCH505A/fmap/sub-49fm2dCH505A_magnitude1.nii.gz",
+        "bids_folder/sub-49fm2dCH505A/fmap/sub-49fm2dCH505A_magnitude2.nii.gz",
+        "bids_folder/sub-49fm2dCH505A/fmap/sub-49fm2dCH505A_magnitude3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-57-fm2d_CH6_-0.5A/fmap/sub-57-fm2d_CH6_-0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-57-fm2d_CH6_-0.5A/fmap/sub-57-fm2d_CH6_-0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-57-fm2d_CH6_-0.5A/fmap/sub-57-fm2d_CH6_-0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-57fm2dCH605A/fmap/sub-57fm2dCH605A_magnitude1.nii.gz",
+        "bids_folder/sub-57fm2dCH605A/fmap/sub-57fm2dCH605A_magnitude2.nii.gz",
+        "bids_folder/sub-57fm2dCH605A/fmap/sub-57fm2dCH605A_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-53-fm2d_CH6_+0.5A/fmap/sub-53-fm2d_CH6_+0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-53-fm2d_CH6_+0.5A/fmap/sub-53-fm2d_CH6_+0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-53-fm2d_CH6_+0.5A/fmap/sub-53-fm2d_CH6_+0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-53fm2dCH605A/fmap/sub-53fm2dCH605A_magnitude1.nii.gz",
+        "bids_folder/sub-53fm2dCH605A/fmap/sub-53fm2dCH605A_magnitude2.nii.gz",
+        "bids_folder/sub-53fm2dCH605A/fmap/sub-53fm2dCH605A_magnitude3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-61-fm2d_CH7_-0.5A/fmap/sub-61-fm2d_CH7_-0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-61-fm2d_CH7_-0.5A/fmap/sub-61-fm2d_CH7_-0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-61-fm2d_CH7_-0.5A/fmap/sub-61-fm2d_CH7_-0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-61fm2dCH705A/fmap/sub-61fm2dCH705A_magnitude1.nii.gz",
+        "bids_folder/sub-61fm2dCH705A/fmap/sub-61fm2dCH705A_magnitude2.nii.gz",
+        "bids_folder/sub-61fm2dCH705A/fmap/sub-61fm2dCH705A_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-59-fm2d_CH7_+0.5A/fmap/sub-59-fm2d_CH7_+0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-59-fm2d_CH7_+0.5A/fmap/sub-59-fm2d_CH7_+0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-59-fm2d_CH7_+0.5A/fmap/sub-59-fm2d_CH7_+0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-59fm2dCH705A/fmap/sub-59fm2dCH705A_magnitude1.nii.gz",
+        "bids_folder/sub-59fm2dCH705A/fmap/sub-59fm2dCH705A_magnitude2.nii.gz",
+        "bids_folder/sub-59fm2dCH705A/fmap/sub-59fm2dCH705A_magnitude3.nii.gz"
       ]
     ],
 
     [
       [
-        "bids_folder/sub-65-fm2d_CH8_-0.5A/fmap/sub-65-fm2d_CH8_-0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-65-fm2d_CH8_-0.5A/fmap/sub-65-fm2d_CH8_-0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-65-fm2d_CH8_-0.5A/fmap/sub-65-fm2d_CH8_-0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-65fm2dCH805A/fmap/sub-65fm2dCH805A_magnitude1.nii.gz",
+        "bids_folder/sub-65fm2dCH805A/fmap/sub-65fm2dCH805A_magnitude2.nii.gz",
+        "bids_folder/sub-65fm2dCH805A/fmap/sub-65fm2dCH805A_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude1.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude2.nii.gz",
-        "bids_folder/sub-27-fm2d_CH0_baseline/fmap/sub-27-fm2d_CH0_baseline_magnitude3.nii.gz"
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude1.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude2.nii.gz",
+        "bids_folder/sub-27fm2dCH0baseline/fmap/sub-27fm2dCH0baseline_magnitude3.nii.gz"
       ],
       [
-        "bids_folder/sub-63-fm2d_CH8_+0.5A/fmap/sub-63-fm2d_CH8_+0.5A_magnitude1.nii.gz",
-        "bids_folder/sub-63-fm2d_CH8_+0.5A/fmap/sub-63-fm2d_CH8_+0.5A_magnitude2.nii.gz",
-        "bids_folder/sub-63-fm2d_CH8_+0.5A/fmap/sub-63-fm2d_CH8_+0.5A_magnitude3.nii.gz"
+        "bids_folder/sub-63fm2dCH805A/fmap/sub-63fm2dCH805A_magnitude1.nii.gz",
+        "bids_folder/sub-63fm2dCH805A/fmap/sub-63fm2dCH805A_magnitude2.nii.gz",
+        "bids_folder/sub-63fm2dCH805A/fmap/sub-63fm2dCH805A_magnitude3.nii.gz"
       ]
     ]
   ],


### PR DESCRIPTION
## Description
This PR updates the scripts and config file to follow the new dcm2bids 3.0 requirements.

## Testing
Follow this [tutorial](https://shimming-toolbox.org/en/latest/user_section/tutorials/create_b0_coil_profiles.html) but use the files from this branch rather than the ones downloaded from "st_download_data data_create_coil_profiles". Also add the DICOMs folder found in the release section.